### PR TITLE
lctr-b2xx/patches/linux: Added device-tree file patch for uart2,4 and gpio

### DIFF
--- a/systems/lctr-b2xx/patches/linux/3.14.16/00-lctr-b2xx-ntnu-x-dts.patch
+++ b/systems/lctr-b2xx/patches/linux/3.14.16/00-lctr-b2xx-ntnu-x-dts.patch
@@ -1,0 +1,128 @@
+diff -ruN linux-3.14.16/arch/arm/boot/dts/am335x-lctr-b2xx-ntnu-gpio.dts linux-3.14.16.kk/arch/arm/boot/dts/am335x-lctr-b2xx-ntnu-gpio.dts
+--- linux-3.14.16/arch/arm/boot/dts/am335x-lctr-b2xx-ntnu-gpio.dts	1970-01-01 01:00:00.000000000 +0100
++++ linux-3.14.16.kk/arch/arm/boot/dts/am335x-lctr-b2xx-ntnu-gpio.dts	2014-10-23 13:22:18.216000000 +0200
+@@ -0,0 +1,56 @@
++/*
++ * Copyright (C) 2014 Universidade do Porto - Faculdade de Engenharia
++ *
++ * This program is free software; you can redistribute it and/or modify
++ * it under the terms of the GNU General Public License version 2 as
++ * published by the Free Software Foundation.
++ */
++
++#include "am335x-lctr-b2xx.dts"
++
++
++/ {
++	/* GPIO. */
++	ntnu_gpio {
++		pinctrl-names = "default";
++		pinctrl-0 = <&gpio_pins>;
++		compatible = "ntnu-gpio";
++		status = "okay";
++	};
++};
++
++&am33xx_pinmux {
++        pinctrl-names = "default";
++        pinctrl-0 = <&board_pins>;
++
++
++
++	/* GPIO on UART2-pins. */
++	gpio_pins: pinmux_gpio_pins {
++		pinctrl-single,pins = <
++			/* GPIO 2 - Pin 22 */
++			0x150 (PIN_INPUT_PULLDOWN | MUX_MODE7)
++			/* GPIO 3 - Pin 21 */
++			0x154 (PIN_OUTPUT_PULLDOWN | MUX_MODE7)
++		>;
++	};
++
++	/* UART4. */
++	uart4_pins: pinmux_uart4_pins {
++		pinctrl-single,pins = <
++			/* uart4_rxd */
++			0x70 (PIN_INPUT_PULLUP | MUX_MODE6)
++			/* uart4_txd */
++			0x74 (PIN_OUTPUT_PULLDOWN | MUX_MODE6)
++		>;
++	};
++};
++
++
++
++/* Enable UART4. */
++&uart4 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&uart4_pins>;
++	status = "okay";
++};
+diff -ruN linux-3.14.16/arch/arm/boot/dts/am335x-lctr-b2xx-ntnu-uart.dts linux-3.14.16.kk/arch/arm/boot/dts/am335x-lctr-b2xx-ntnu-uart.dts
+--- linux-3.14.16/arch/arm/boot/dts/am335x-lctr-b2xx-ntnu-uart.dts	1970-01-01 01:00:00.000000000 +0100
++++ linux-3.14.16.kk/arch/arm/boot/dts/am335x-lctr-b2xx-ntnu-uart.dts	2014-10-20 21:35:33.608000000 +0200
+@@ -0,0 +1,52 @@
++/*
++ * Copyright (C) 2014 Universidade do Porto - Faculdade de Engenharia
++ *
++ * This program is free software; you can redistribute it and/or modify
++ * it under the terms of the GNU General Public License version 2 as
++ * published by the Free Software Foundation.
++ */
++
++#include "am335x-lctr-b2xx.dts"
++
++
++
++&am33xx_pinmux {
++        pinctrl-names = "default";
++        pinctrl-0 = <&board_pins>;
++
++
++
++	/* UART2. */
++	uart2_pins: pinmux_uart2_pins {
++		pinctrl-single,pins = <
++			/* uart2_rxd */
++			0x150 (PIN_INPUT_PULLUP | MUX_MODE1)
++			/* uart2_txd */
++			0x154 (PIN_OUTPUT_PULLDOWN | MUX_MODE1)
++		>;
++	};
++
++	/* UART4. */
++	uart4_pins: pinmux_uart4_pins {
++		pinctrl-single,pins = <
++			/* uart4_rxd */
++			0x70 (PIN_INPUT_PULLUP | MUX_MODE6)
++			/* uart4_txd */
++			0x74 (PIN_OUTPUT_PULLDOWN | MUX_MODE6)
++		>;
++	};
++};
++
++/* Enable UART2. */
++&uart2 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&uart2_pins>;
++	status = "okay";
++};
++
++/* Enable UART4. */
++&uart4 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&uart4_pins>;
++	status = "okay";
++};
+diff -ruN linux-3.14.16/arch/arm/boot/dts/Makefile linux-3.14.16.kk/arch/arm/boot/dts/Makefile
+--- linux-3.14.16/arch/arm/boot/dts/Makefile	2014-08-08 01:50:59.000000000 +0200
++++ linux-3.14.16.kk/arch/arm/boot/dts/Makefile	2014-10-23 13:24:50.292000000 +0200
+@@ -227,6 +227,8 @@
+ 	am335x-bone.dtb \
+ 	am335x-boneblack.dtb \
+ 	am335x-nano.dtb \
++	am335x-lctr-b2xx-ntnu-uart.dtb \
++	am335x-lctr-b2xx-ntnu-gpio.dtb \
+ 	am335x-base0033.dtb \
+ 	am3517-evm.dtb \
+ 	am3517_mt_ventoux.dtb \


### PR DESCRIPTION
This creates two new device-trees for lctr-b2xx.

am335x-lctr-b2xx-ntnu-gpio: Enables UART4. GPIO_0[2](gpio 2, pin 22) as input, pulldown. GPIO_0[3](gpio 3, pin 21) as output, pulldown.
am335x-lctr-b2xx-ntnu-uart: Enables UART4 and UART2.
