### PR TITLE
libusb: Use single process for building due to Makefile bug

### DIFF
--- a/rules/libusb/default.bash
+++ b/rules/libusb/default.bash
@@ -34,7 +34,7 @@ configure()
 
 build()
 {
-    $cmd_make
+    make
 }
 
 host_install()


### PR DESCRIPTION
I had troubles building this, and switching to single-process resolved the issue. 

See related discussion here: http://sourceforge.net/p/libusb/mailman/message/34454335/

I don't know why this happened on my computer though, and not on yours. 