### PR TITLE
Copy libopencv_* to /lib/, for cross-compilation of DUNE

### DIFF
--- a/rules/opencv/default.bash
+++ b/rules/opencv/default.bash
@@ -63,6 +63,11 @@ host_install()
 {
     cd  ${pkg_build_dir}/../build &&
     $cmd_make install
+
+    # make available for cross compilation
+    for f in "$cfg_dir_toolchain_sysroot/usr/lib/"libopencv*so*; do
+       ln -s -f "$f" "$cfg_dir_toolchain/lib"
+    done
 }
 
 target_install()


### PR DESCRIPTION
Note that this is the same code as in the target_install-step, but with a different destination. Could have put this code there, but I felt that it belonged in the host_install-step.