### PR TITLE
Copy libcurl_* to /lib/, for cross-compilation of DUNE

### DIFF
--- a/rules/curl/default.bash
+++ b/rules/curl/default.bash
@@ -35,6 +35,11 @@ build()
 host_install()
 {
     $cmd_make install
+    # make available for cross compilation
+    for f in "${cfg_dir_toolchain_sysroot}/usr/lib/"libcurl*so*; do
+        echo "Doing $f"
+        ln -s -f "$f" "${cfg_dir_toolchain}/lib"
+    done
 }
 
 target_install()


### PR DESCRIPTION
Note that this is the same code as in the target_install-step, but with a different destination. Could have put this code there, but I felt that it belonged in the host_install-step.